### PR TITLE
Inspect route labeled resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ default    goapp-first                          | |  | L Service          -
 default    goapp-first-rctct                    | |  | L Service          -
 default    goapp-first-5d4rn                    | |  L Service            -
 default    goapp                                L Route                   True
+default    goapp                                 L Service                -
+default    goapp                                 L Ingress                True
+default    goapp-mesh                             L VirtualService        -
+default    goapp                                  L VirtualService        -
 ```
 
 ## Inspect Changes in ConfigMaps


### PR DESCRIPTION
Thanks for publishing such a useful tool ! I played with this for a while and noticed a missing piece.
I think it would get better to inspect route labeled resources as described below:

```
$ ./kni inspect -s account
Resources in account

Namespace  Name                                            Kind                       Ready  Reason
default    account                                         Service                    True
default    account                                           L Configuration          True
default    account-grpc-v0-4-0                               | L Revision             True
default    account-grpc-v0-4-0-deployment                    |  L Deployment          -
default    account-grpc-v0-4-0-deployment-b698f99d6          |  | L ReplicaSet        -
default    account-grpc-v0-4-0-deployment-b698f99d6-szvqc    |  |  L Pod              True
default    account-grpc-v0-4-0-cache                         |  L Image               -
default    account-grpc-v0-4-0                               |  L PodAutoscaler       True
default    account-grpc-v0-4-0                               |   L Metric             True
default    account-grpc-v0-4-0                               |   L ServerlessService  True
default    account-grpc-v0-4-0-b2d2w                         |   | L Service          -
default    account-grpc-v0-4-0                               |   | L Service          -
default    account-grpc-v0-4-0                               |   | L Endpoints        -
default    account-grpc-v0-4-0-metrics                       |   L Service            -
default    account                                           L Route                  True
default    account                                            L Service               -
default    account                                            L Ingress               True
default    account-mesh                                        L VirtualService       -
default    account                                             L VirtualService       -


20 resources
```